### PR TITLE
Add content script palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root" class="extension-popup"></div>
     <script type="module" src="/src/popup/main.tsx"></script>
   </body>
 </html>

--- a/src/contentScript/index.tsx
+++ b/src/contentScript/index.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import { CommandPalette } from '../popup/components/CommandPalette';
+import '../popup/index.css';
+
+const containerId = 'moskeyto-command-palette-container';
+let container = document.getElementById(containerId);
+if (!container) {
+  container = document.createElement('div');
+  container.id = containerId;
+  container.style.zIndex = '2147483647';
+  document.body.appendChild(container);
+}
+const root = ReactDOM.createRoot(container!);
+
+const App = () => {
+  const [opened, setOpened] = useState(false);
+
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.altKey && e.key.toLowerCase() === 'k') {
+        setOpened(true);
+        e.preventDefault();
+      } else if (e.key === 'Escape') {
+        setOpened(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, []);
+
+  return (
+    <MantineProvider withGlobalStyles={false} withNormalizeCSS={true}>
+      <CommandPalette opened={opened} onClose={() => setOpened(false)} />
+    </MantineProvider>
+  );
+};
+
+root.render(<App />);
+

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -12,6 +12,7 @@ import {
 import { commonValue, targetUrls } from "../CommonValue";
 import React, { useEffect, useState } from 'react';
 import { Bookmarks } from './pages/Bookmarks';
+import { CommandPalette } from './components/CommandPalette';
 import AppIcon from '/public/icon/icon.svg';
 import { useRef } from 'react';
 
@@ -19,6 +20,7 @@ export const App: React.FC = () => {
   const [isAltPressed, setIsAltPressed] = useState(false);
   const [inputRef, setInputRef] = useState<any>(null);
   const linkRefs:any = useRef([]);
+  const [paletteOpened, setPaletteOpened] = useState(false);
 
   // キー入力の待ち受け
   useEffect(() => {
@@ -41,6 +43,12 @@ export const App: React.FC = () => {
         }
         console.log(linkRefs);
         console.log('Alt + j');
+      } else if (e.key === 'k' && isAltPressed) {
+        // Alt + k
+        setPaletteOpened(true);
+        e.preventDefault();
+      } else if (e.key === 'Escape') {
+        setPaletteOpened(false);
       }
       // テキスト入力エリアである場合、イベントを無視する
       if (e.target?.tagName === 'INPUT' || e.target?.tagName === 'TEXTAREA') {
@@ -67,6 +75,7 @@ export const App: React.FC = () => {
 
   return (
     <MantineProvider withGlobalStyles={false} withNormalizeCSS={true}>
+      <CommandPalette opened={paletteOpened} onClose={() => setPaletteOpened(false)} />
       <Container size={600}>
         <header>
           <Group>

--- a/src/popup/components/CommandPalette.tsx
+++ b/src/popup/components/CommandPalette.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useRef } from 'react';
+import { Modal, List } from '@mantine/core';
+import { BookmarkListForm } from './BookmarkListForm';
+import { BookmarkListItem } from './BookmarkListItem';
+import { useBookmarkData } from '../hooks/UseBookmarkData';
+import { useKeywordData } from '../hooks/UseKeywordData';
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+};
+
+export const CommandPalette: React.FC<Props> = ({ opened, onClose }) => {
+  const { keyword, handleChangeKeyword } = useKeywordData();
+  const { bookmarks } = useBookmarkData(keyword);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const linkRefs: any = useRef([]);
+
+  useEffect(() => {
+    if (opened) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [opened]);
+
+  return (
+    <Modal opened={opened} onClose={onClose} centered overlayBlur={3} withinPortal={false}>
+      <BookmarkListForm
+        onChange={handleChangeKeyword}
+        bookmarkLength={bookmarks.length}
+        setInputRef={(ref) => (inputRef.current = ref)}
+      />
+      {bookmarks.length > 0 && (
+        <List type="ordered" mt="md">
+          {bookmarks.map((bookmark, index) => (
+            <BookmarkListItem key={bookmark.url} bookmark={bookmark} index={index} linkRefs={linkRefs} />
+          ))}
+        </List>
+      )}
+    </Modal>
+  );
+};

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -24,8 +24,7 @@ body::-webkit-scrollbar-thumb {
   }
 
 /* Main */
-body {
-  /* width: max-content; */
+#root.extension-popup {
   width: 600px;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,10 @@ const manifest = defineManifest({
   },
   background: { service_worker: "src/background/index.ts" },
   content_scripts: [
+    {
+      matches: ["<all_urls>"],
+      js: ["src/contentScript/index.tsx"],
+    },
   ],
   commands: {
     _execute_action: {


### PR DESCRIPTION
## Summary
- fix popup width style
- show CommandPalette as a centered modal
- inject command palette on all sites when pressing Ctrl+Alt+K

## Testing
- `npm run fmt` *(fails: `rome` not found)*
